### PR TITLE
Allow setting any ExtractText plugin options.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,22 +12,21 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin')
  * -------------------------------------------------------------------------- */
 
 module.exports = (neutrino, options = {}) => {
+  const { loaderOptions = {}, pluginOptions = {} } = options
+  const styleRule = neutrino.config.module
+    .rule('style')
+    .test(loaderOptions.test || /\.css$/)
+
+  const loaders = ExtractTextPlugin.extract({
+    fallback: loaderOptions.fallback || 'style-loader',
+    use: loaderOptions.use || 'css-loader'
+  })
+
   // We want to start from a clean slate. This removes any existing "style"
   // rule that may exist (present if using the default neutrino-preset-web).
   neutrino.config.module.rules.delete('style')
 
-  options.extractText = Object.assign({
-    filename: options.filename || '[name].css',
-  }, options.extractText)
-
-  const styleRule = neutrino.config.module
-    .rule('style')
-    .test(options.test || /\.css$/)
-
-  const loaders = ExtractTextPlugin.extract({
-    fallback: options.fallback || 'style-loader',
-    use: options.use || 'css-loader'
-  })
+  pluginOptions.filename = pluginOptions.filename || '[name].css'
 
   loaders.forEach(({ loader, options }) => styleRule.use(loader)
     .loader(loader)
@@ -35,5 +34,5 @@ module.exports = (neutrino, options = {}) => {
   )
 
   neutrino.config.plugin('extract')
-    .use(ExtractTextPlugin, [options.extractText])
+    .use(ExtractTextPlugin, [pluginOptions])
 }

--- a/src/index.js
+++ b/src/index.js
@@ -17,10 +17,10 @@ module.exports = (neutrino, options = {}) => {
     .rule('style')
     .test(loaderOptions.test || /\.css$/)
 
-  const loaders = ExtractTextPlugin.extract({
-    fallback: loaderOptions.fallback || 'style-loader',
-    use: loaderOptions.use || 'css-loader'
-  })
+  const loaders = ExtractTextPlugin.extract(Object.assign({
+    fallback: 'style-loader',
+    use: 'css-loader'
+  }, loaderOptions))
 
   // We want to start from a clean slate. This removes any existing "style"
   // rule that may exist (present if using the default neutrino-preset-web).

--- a/src/index.js
+++ b/src/index.js
@@ -26,13 +26,11 @@ module.exports = (neutrino, options = {}) => {
   // rule that may exist (present if using the default neutrino-preset-web).
   neutrino.config.module.rules.delete('style')
 
-  pluginOptions.filename = pluginOptions.filename || '[name].css'
-
   loaders.forEach(({ loader, options }) => styleRule.use(loader)
     .loader(loader)
     .options(options)
   )
 
   neutrino.config.plugin('extract')
-    .use(ExtractTextPlugin, [pluginOptions])
+    .use(ExtractTextPlugin, [Object.assign({ filename: '[name].css' }, pluginOptions)])
 }

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,10 @@ module.exports = (neutrino, options = {}) => {
   // rule that may exist (present if using the default neutrino-preset-web).
   neutrino.config.module.rules.delete('style')
 
+  options.extractText = Object.assign({
+    filename: options.filename || '[name].css',
+  }, options.extractText)
+
   const styleRule = neutrino.config.module
     .rule('style')
     .test(options.test || /\.css$/)
@@ -31,5 +35,5 @@ module.exports = (neutrino, options = {}) => {
   )
 
   neutrino.config.plugin('extract')
-    .use(ExtractTextPlugin, [options.filename || '[name].css'])
+    .use(ExtractTextPlugin, [options.extractText])
 }


### PR DESCRIPTION
We can set the filename, but ExtractText has other options options as well.

This way, users won't have to do something like: 
```
  neutrino.config
  .plugin('extract')
    .tap(args => {
      return [{
        filename: '[name].[chunkhash].bundle.css',
        allChunks: true,
        ignoreOrder:  true,
      }]
    })
    .end()
  ;
```

I put the options in `options.extractText`, could just as easily be in a second argument:

```
module.exports = (neutrino, options = {}, extractTextOptions = {}) => {
```